### PR TITLE
Added dockerfile-maven-plugin

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,4 +24,6 @@ Sonatype internal people:
 
 External contributors:
 
+* [@mgh87](https://github.com/mgh87/) (Martin Huter)
+
 ![Possibly You!](http://i.imgur.com/A3eScYul.jpg)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ If everything checks out, the bundle for P2 should be available in the `target` 
 
 #### Build with Docker
 
-`docker build -t nexus-repository-p2:1.0.0 .`
+ The dockerfile needs the created jar in the target folder and is using it. This can be accomplished by building the artifact first or doing it within the execution of the docker build:
+
+    mvn clean package dockerfile:build
 
 #### Run as a Docker container
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
   <inceptionYear>2017</inceptionYear>
   <packaging>bundle</packaging>
 
+  <properties>
+    <docker.image.prefix>sonatype</docker.image.prefix>
+  </properties>
+
   <dependencies>
 
     <dependency>
@@ -97,6 +101,20 @@
         <version>2.20</version>
       </plugin>
 
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>dockerfile-maven-plugin</artifactId>
+        <version>1.3.6</version>
+          <configuration>
+            <repository>${docker.image.prefix}/${project.artifactId}</repository>
+            <tag>${project.version}</tag>
+            <buildArgs>
+              <TARGET>target</TARGET>
+              <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+              <P2_VERSION>${project.version}</P2_VERSION>
+            </buildArgs>
+          </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
To integrate the docker image creation into the maven build the dockerfile-maven-plugin was added

This pull request makes the following changes:
* Used the version of the pom to deploy the OSGi artifact within the features of the nexus bundles
* Maven build removed from the docker file, because it can use the artifact that is created by the maven build process

A dynamic binding to the version of the parent pom is not possible because this is a non usable property in maven, thats the reason why the version number of the nexus docker image is still static