### PR TITLE
added missing flush/close of reader and writer (repairs failing unit-tests)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,4 +24,6 @@ Sonatype internal people:
 
 External contributors:
 
+* [@mgh87](https://github.com/mgh87/) (Martin Huter)
+
 ![Possibly You!](http://i.imgur.com/A3eScYul.jpg)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ If everything checks out, the bundle for P2 should be available in the `target` 
 
 #### Build with Docker
 
-`docker build -t nexus-repository-p2:1.0.0 .`
+ The dockerfile needs the created jar in the target folder and is using it. This can be accomplished by building the artifact first or doing it within the execution of the docker build:
+
+    mvn clean package dockerfile:build
 
 #### Run as a Docker container
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
       <plugin>
         <groupId>com.spotify</groupId>
         <artifactId>dockerfile-maven-plugin</artifactId>
-        <version>1.3.6</version>
+        <version>1.4.3</version>
           <configuration>
             <repository>${docker.image.prefix}/${project.artifactId}</repository>
             <tag>${project.version}</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
   <inceptionYear>2017</inceptionYear>
   <packaging>bundle</packaging>
 
+  <properties>
+    <docker.image.prefix>sonatype</docker.image.prefix>
+  </properties>
+
   <dependencies>
 
     <dependency>
@@ -97,6 +101,20 @@
         <version>2.20</version>
       </plugin>
 
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>dockerfile-maven-plugin</artifactId>
+        <version>1.3.6</version>
+          <configuration>
+            <repository>${docker.image.prefix}/${project.artifactId}</repository>
+            <tag>${project.version}</tag>
+            <buildArgs>
+              <TARGET>target</TARGET>
+              <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+              <P2_VERSION>${project.version}</P2_VERSION>
+            </buildArgs>
+          </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/org/sonatype/nexus/repository/p2/internal/metadata/ArtifactsXmlAbsoluteUrlRemover.java
+++ b/src/main/java/org/sonatype/nexus/repository/p2/internal/metadata/ArtifactsXmlAbsoluteUrlRemover.java
@@ -94,6 +94,10 @@ public class ArtifactsXmlAbsoluteUrlRemover
             XMLEventWriter writer = outputFactory.createXMLEventWriter(xmlOut);
 
             streamXmlToWriterAndRemoveAbsoluteUrls(reader, writer);
+			
+            reader.close();
+            writer.flush();
+            writer.close();
           }
           return convertFileToTempBlob(tempFile, repository);
         }


### PR DESCRIPTION
Try to build the plugin locally, but get failing unit-tests (with Windows10, Java8u181, Maven3.5).
After adding close for reader and writer, the unit-tests are working again.

This pull request makes the following changes:
* added missing flush/close of reader and writer (repairs failing unit-tests)

It relates to the following issue #s:
* failing unit-tests
