### PR TITLE
Close XMLEventReader and XMLEventWriter to avoid shrinking of XML

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,4 +24,7 @@ Sonatype internal people:
 
 External contributors:
 
+* [@afischer211](https://github.com/afischer211/) (Alexander Fischer)
+* [@ruspl-afed](https://github.com/ruspl-afed/) (Alexander Fedorov)
+
 ![Possibly You!](http://i.imgur.com/A3eScYul.jpg)

--- a/src/main/java/org/sonatype/nexus/repository/p2/internal/metadata/ArtifactsXmlAbsoluteUrlRemover.java
+++ b/src/main/java/org/sonatype/nexus/repository/p2/internal/metadata/ArtifactsXmlAbsoluteUrlRemover.java
@@ -92,6 +92,7 @@ public class ArtifactsXmlAbsoluteUrlRemover
             XMLOutputFactory outputFactory = XMLOutputFactory.newFactory();
             XMLEventReader reader = null;
             XMLEventWriter writer = null;
+            //try-with-resources will be better here, but XMLEventReader and XMLEventWriter are not AutoCloseable
             try {
               reader = inputFactory.createXMLEventReader(xmlIn);
               writer = outputFactory.createXMLEventWriter(xmlOut);

--- a/src/main/java/org/sonatype/nexus/repository/p2/internal/metadata/ArtifactsXmlAbsoluteUrlRemover.java
+++ b/src/main/java/org/sonatype/nexus/repository/p2/internal/metadata/ArtifactsXmlAbsoluteUrlRemover.java
@@ -90,10 +90,21 @@ public class ArtifactsXmlAbsoluteUrlRemover
           try (OutputStream xmlOut = xmlOutputStream(extension, tempFile)) {
             XMLInputFactory inputFactory = XMLInputFactory.newFactory();
             XMLOutputFactory outputFactory = XMLOutputFactory.newFactory();
-            XMLEventReader reader = inputFactory.createXMLEventReader(xmlIn);
-            XMLEventWriter writer = outputFactory.createXMLEventWriter(xmlOut);
-
-            streamXmlToWriterAndRemoveAbsoluteUrls(reader, writer);
+            XMLEventReader reader = null;
+            XMLEventWriter writer = null;
+            try {
+              reader = inputFactory.createXMLEventReader(xmlIn);
+              writer = outputFactory.createXMLEventWriter(xmlOut);
+              streamXmlToWriterAndRemoveAbsoluteUrls(reader, writer);
+              writer.flush();
+            } finally {
+              if (reader != null) {
+                reader.close();
+              }
+              if (writer != null) {
+                writer.close();
+              }
+            }
           }
           return convertFileToTempBlob(tempFile, repository);
         }


### PR DESCRIPTION
On some PCs under Windows it shrinks the XML inside the JAR for p2 proxy, so it is impossible to use p2 proxy sites. The bug appears at least under Windows 8.1 JDK 1.8 x64

This pull request makes the following changes:
* XMLEventReader and XMLEventWriter are closed after usage to avoid shrinking of XML, based on solution suggested by @afischer211
* updated contributors accroding to [contributing guidelines](https://github.com/sonatype-nexus-community/nexus-repository-p2/blob/master/.github/CONTRIBUTING.md)

It relates to the following issue #s:
* Fixes #9
