### PR TITLE
Fix: Update maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20</version>
+        <version>2.22.1</version>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+
       </plugin>
 
     </plugins>


### PR DESCRIPTION
This pull request makes the following changes:

* Update maven-surefire-plugin to 2.22.1
* set `useSystemClassLoader` to `false` for maven-sirefire-plugin

It relates to the following issue #s:

* Fixes #13 
