### PR TITLE
Update Dockerfile to nexus3 version 3.15.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
-ARG NEXUS_VERSION=3.8.0
+ARG NEXUS_VERSION=3.15.2
 
 FROM maven:3-jdk-8-alpine AS build
-ARG NEXUS_VERSION=3.8.0
-ARG NEXUS_BUILD=02
+ARG NEXUS_VERSION=3.15.2
+ARG NEXUS_BUILD=01
 
 COPY . /nexus-repository-p2/
 RUN cd /nexus-repository-p2/; sed -i "s/3.8.0-02/${NEXUS_VERSION}-${NEXUS_BUILD}/g" pom.xml; \
     mvn clean package;
 
 FROM sonatype/nexus3:$NEXUS_VERSION
-ARG NEXUS_VERSION=3.8.0
-ARG NEXUS_BUILD=02
+ARG NEXUS_VERSION=3.15.2
+ARG NEXUS_BUILD=01
 ARG P2_VERSION=0.0.2
 ARG TARGET_DIR=/opt/sonatype/nexus/system/org/sonatype/nexus/plugins/nexus-repository-p2/${P2_VERSION}/
 USER root
 RUN mkdir -p ${TARGET_DIR}; \
-    sed -i 's@nexus-repository-npm</feature>@nexus-repository-npm</feature>\n        <feature prerequisite="false" dependency="false">nexus-repository-p2</feature>@g' /opt/sonatype/nexus/system/com/sonatype/nexus/assemblies/nexus-oss-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-oss-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml; \
-    sed -i 's@<feature name="nexus-repository-npm"@<feature name="nexus-repository-p2" description="org.sonatype.nexus.plugins:nexus-repository-p2" version="0.0.2">\n        <details>org.sonatype.nexus.plugins:nexus-repository-p2</details>\n        <bundle>mvn:org.sonatype.nexus.plugins/nexus-repository-p2/0.0.2</bundle>\n    </feature>\n    <feature name="nexus-repository-npm"@g' /opt/sonatype/nexus/system/com/sonatype/nexus/assemblies/nexus-oss-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-oss-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml;
+    sed -i 's@repository-rubygems</feature>@repository-rubygems</feature>\n        <feature prerequisite="false" dependency="false">nexus-repository-p2</feature>@g' /opt/sonatype/nexus/system/com/sonatype/nexus/assemblies/nexus-oss-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-oss-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml; \
+    sed -i 's@<feature name="nexus-repository-rubygems"@<feature name="nexus-repository-p2" description="org.sonatype.nexus.plugins:nexus-repository-p2" version="0.0.2">\n        <details>org.sonatype.nexus.plugins:nexus-repository-p2</details>\n        <bundle>mvn:org.sonatype.nexus.plugins/nexus-repository-p2/0.0.2</bundle>\n    </feature>\n    <feature name="nexus-repository-rubygems"@g' /opt/sonatype/nexus/system/com/sonatype/nexus/assemblies/nexus-oss-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-oss-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml;
 COPY --from=build /nexus-repository-p2/target/nexus-repository-p2-${P2_VERSION}.jar ${TARGET_DIR}
 USER nexus


### PR DESCRIPTION
Updated nexus version to 3.15.2-01 because of Security Fix for discovered CVE

"A security vulnerability has been found and corrected in 3.15.0. For details, please see CVE-2019-7238.
Sonatype recommends that administrators running NXRM3 versions up to and including 3.14.0 upgrade immediately."

This pull request makes the following changes:
* Updated NEXUS_Version args
* Changed possition within .../nexus-oss-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml


It relates to the following issue #s:
* [CVE-2019-7238](https://support.sonatype.com/hc/en-us/articles/360017310793-CVE-2019-7238-Nexus-Repository-Manager-3-Missing-Access-Controls-and-Remote-Code-Execution-February-5th-2019)

Only tested p2 and maven repositories.
