### PR TITLE
NEXUS-22489 fixed IT updates

### DIFF
--- a/nexus-repository-p2-it/pom.xml
+++ b/nexus-repository-p2-it/pom.xml
@@ -78,7 +78,7 @@
       <type>zip</type>
       <scope>test</scope>
       <exclusions>
-        <!-- Avoid leaking older r plugins from distro -->
+        <!-- Avoid leaking older p2 plugins from distro -->
         <exclusion>
           <groupId>org.sonatype.nexus.plugins</groupId>
           <artifactId>nexus-repository-p2</artifactId>

--- a/nexus-repository-p2-it/pom.xml
+++ b/nexus-repository-p2-it/pom.xml
@@ -77,6 +77,17 @@
       <version>${nxrm-version}</version>
       <type>zip</type>
       <scope>test</scope>
+      <exclusions>
+        <!-- Avoid leaking older r plugins from distro -->
+        <exclusion>
+          <groupId>org.sonatype.nexus.plugins</groupId>
+          <artifactId>nexus-repository-p2</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.sonatype.nexus.plugins</groupId>
+          <artifactId>nexus-restore-p2</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.sonatype.nexus.plugins</groupId>

--- a/nexus-repository-p2-it/src/test/java/org/sonatype/nexus/repository/p2/P2ITConfig.java
+++ b/nexus-repository-p2-it/src/test/java/org/sonatype/nexus/repository/p2/P2ITConfig.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.repository.p2;
 
 import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;

--- a/nexus-repository-p2-it/src/test/java/org/sonatype/nexus/repository/p2/P2ITConfig.java
+++ b/nexus-repository-p2-it/src/test/java/org/sonatype/nexus/repository/p2/P2ITConfig.java
@@ -1,0 +1,20 @@
+package org.sonatype.nexus.repository.p2;
+
+import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
+import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
+
+import org.ops4j.pax.exam.Option;
+
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+import static org.sonatype.nexus.pax.exam.NexusPaxExamSupport.nexusFeature;
+
+public class P2ITConfig
+{
+  public static Option[] configureP2Base() {
+    return NexusPaxExamSupport.options(
+        NexusITSupport.configureNexusBase(),
+        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-p2"),
+        systemProperty("nexus-exclude-features").value("nexus-cma-community")
+    );
+  }
+}

--- a/nexus-repository-p2-it/src/test/java/org/sonatype/nexus/repository/p2/internal/P2ProxyIT.java
+++ b/nexus-repository-p2-it/src/test/java/org/sonatype/nexus/repository/p2/internal/P2ProxyIT.java
@@ -17,13 +17,11 @@ import java.io.InputStream;
 
 import org.sonatype.goodies.httpfixture.server.fluent.Behaviours;
 import org.sonatype.goodies.httpfixture.server.fluent.Server;
-import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.http.HttpStatus;
 import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.Component;
 import org.sonatype.nexus.repository.storage.ComponentMaintenance;
-import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
@@ -37,6 +35,7 @@ import org.ops4j.pax.exam.Option;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.sonatype.nexus.repository.p2.P2ITConfig.configureP2Base;
 import static org.sonatype.nexus.testsuite.testsupport.FormatClientSupport.status;
 
 public class P2ProxyIT
@@ -152,10 +151,7 @@ public class P2ProxyIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-p2")
-    );
+    return configureP2Base();
   }
 
   @Before

--- a/nexus-repository-p2-it/src/test/java/org/sonatype/nexus/repository/p2/internal/P2RestoreBlobIT.java
+++ b/nexus-repository-p2-it/src/test/java/org/sonatype/nexus/repository/p2/internal/P2RestoreBlobIT.java
@@ -36,7 +36,6 @@ import org.sonatype.nexus.repository.p2.internal.proxy.P2ProxyRecipe;
 import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.AssetEntityAdapter;
 import org.sonatype.nexus.repository.storage.StorageTx;
-import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
 import org.sonatype.nexus.testsuite.testsupport.blobstore.restore.BlobstoreRestoreTestHelper;
 
 import static org.hamcrest.Matchers.is;
@@ -44,6 +43,7 @@ import static org.junit.Assert.assertThat;
 import static org.sonatype.nexus.blobstore.api.BlobAttributesConstants.HEADER_PREFIX;
 import static org.sonatype.nexus.blobstore.api.BlobStore.BLOB_NAME_HEADER;
 import static org.sonatype.nexus.blobstore.api.BlobStore.CONTENT_TYPE_HEADER;
+import static org.sonatype.nexus.repository.p2.P2ITConfig.configureP2Base;
 import static org.sonatype.nexus.repository.storage.Bucket.REPO_NAME_HEADER;
 
 public class P2RestoreBlobIT
@@ -65,8 +65,7 @@ public class P2RestoreBlobIT
   @Configuration
   public static Option[] configureNexus() {
     return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-p2"),
+        configureP2Base(),
         nexusFeature("org.sonatype.nexus.plugins", "nexus-restore-p2")
     );
   }

--- a/nexus-repository-p2-it/src/test/java/org/sonatype/nexus/repository/p2/internal/P2RoutingRuleIT.java
+++ b/nexus-repository-p2-it/src/test/java/org/sonatype/nexus/repository/p2/internal/P2RoutingRuleIT.java
@@ -27,15 +27,14 @@ import org.ops4j.pax.exam.Option;
 import org.sonatype.goodies.httpfixture.server.fluent.Behaviours;
 import org.sonatype.goodies.httpfixture.server.fluent.Server;
 import org.sonatype.nexus.common.entity.EntityId;
-import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
 import org.sonatype.nexus.repository.Repository;
-import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
 import org.sonatype.nexus.testsuite.testsupport.raw.RawClient;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.sonatype.nexus.repository.p2.P2ITConfig.configureP2Base;
 
 /**
  * @since 0.next
@@ -48,10 +47,7 @@ public class P2RoutingRuleIT extends P2RoutingRuleITSupport
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-p2")
-    );
+    return configureP2Base();
   }
 
   @Before

--- a/nexus-repository-p2-it/src/test/java/org/sonatype/nexus/repository/p2/internal/cleanup/CleanupTaskP2ProxyIT.java
+++ b/nexus-repository-p2-it/src/test/java/org/sonatype/nexus/repository/p2/internal/cleanup/CleanupTaskP2ProxyIT.java
@@ -31,13 +31,13 @@ import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.p2.internal.P2Client;
 import org.sonatype.nexus.repository.p2.internal.fixtures.RepositoryRuleP2;
-import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
 import org.sonatype.nexus.testsuite.testsupport.cleanup.CleanupITSupport;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.sonatype.nexus.repository.http.HttpStatus.OK;
+import static org.sonatype.nexus.repository.p2.P2ITConfig.configureP2Base;
 import static org.sonatype.nexus.repository.p2.internal.P2ITSupport.PACKAGE_NAME;
 import static org.sonatype.nexus.repository.p2.internal.P2ITSupport.HELP_PACKAGE_NAME;
 import static org.sonatype.nexus.repository.p2.internal.P2ITSupport.VALID_HELP_PACKAGE_URL;
@@ -58,10 +58,7 @@ public class CleanupTaskP2ProxyIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-p2")
-    );
+    return configureP2Base();
   }
 
   @Before

--- a/nexus-repository-p2/src/test/java/org/sonatype/nexus/repository/p2/internal/P2FacetTest.java
+++ b/nexus-repository-p2/src/test/java/org/sonatype/nexus/repository/p2/internal/P2FacetTest.java
@@ -151,7 +151,7 @@ public class P2FacetTest
   @Test
   public void toContent() {
     Content content = underTest.toContent(asset, blob);
-    assertThat(content.getAttributes().get("lastModified"), is(notNullValue()));
+    assertThat(content.getAttributes().get("last_modified"), is(notNullValue()));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.23.0-01</version>
+    <version>3.25.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>p2-parent</artifactId>
@@ -48,7 +48,7 @@
   </distributionManagement>
 
   <properties>
-    <nxrm-version>3.23.0-01</nxrm-version>
+    <nxrm-version>3.25.0-SNAPSHOT</nxrm-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
ITs now use the actual repository code instead of the version of the plugin from the parent (NXRM)

The issue explains the problem for R format https://issues.sonatype.org/browse/NEXUS-22489